### PR TITLE
Report tests with errors

### DIFF
--- a/test-runner.clj
+++ b/test-runner.clj
@@ -6,6 +6,11 @@
          '[clojure.string :as str]
          '[rewrite-clj.zip :as z])
 
+(comment
+  (def slug "tracks-on-tracks-on-tracks")
+  (def in-dir "/home/porky/exercism/clojure-test-runner/exercises/concept/tracks-on-tracks-on-tracks/")
+  )
+
 ;; Add solution source and tests to classpath
 (def slug (first *command-line-args*))
 (def in-dir (second *command-line-args*))
@@ -84,6 +89,8 @@
 
 ;; Produce JSON output
 
+@errors
+
 (println (json/generate-string
       {:version 2
        :status (if (and (empty? @fails)
@@ -95,7 +102,10 @@
                        {:name test :status "pass" :test_code (str (test (test-code-map zloc)))}
                        (contains? (set (map :name @fails)) test)
                        {:name test :status "fail" :test_code (str (test (test-code-map zloc)))
-                        :message (:message (first (filter #(= test (:name %)) @fails)))})))
+                        :message (:message (first (filter #(= test (:name %)) @fails)))}
+                       (contains? (set (map :name @errors)) test)
+                       {:name test :status "error" :test_code (str (test (test-code-map zloc)))
+                        :message (:message (first (filter #(= test (:name %)) @errors)))})))
        :message (when (seq @errors)
                   @errors)}
       {:pretty true}))

--- a/test-runner.clj
+++ b/test-runner.clj
@@ -6,11 +6,6 @@
          '[clojure.string :as str]
          '[rewrite-clj.zip :as z])
 
-(comment
-  (def slug "tracks-on-tracks-on-tracks")
-  (def in-dir "/home/porky/exercism/clojure-test-runner/exercises/concept/tracks-on-tracks-on-tracks/")
-  )
-
 ;; Add solution source and tests to classpath
 (def slug (first *command-line-args*))
 (def in-dir (second *command-line-args*))
@@ -89,8 +84,6 @@
 
 ;; Produce JSON output
 
-@errors
-
 (println (json/generate-string
       {:version 2
        :status (if (and (empty? @fails)
@@ -103,7 +96,7 @@
                        (contains? (set (map :name @fails)) test)
                        {:name test :status "fail" :test_code (str (test (test-code-map zloc)))
                         :message (:message (first (filter #(= test (:name %)) @fails)))}
-                       (contains? (set (map :name @errors)) test)
+                       (contains? (set (set @errors)) test)
                        {:name test :status "error" :test_code (str (test (test-code-map zloc)))
                         :message (:message (first (filter #(= test (:name %)) @errors)))})))
        :message (when (seq @errors)

--- a/test-runner.clj
+++ b/test-runner.clj
@@ -98,9 +98,7 @@
                         :message (:message (first (filter #(= test (:name %)) @fails)))}
                        (contains? (set (set @errors)) test)
                        {:name test :status "error" :test_code (str (test (test-code-map zloc)))
-                        :message (:message (first (filter #(= test (:name %)) @errors)))})))
-       :message (when (seq @errors)
-                  @errors)}
+                        :message (:message (first (filter #(= test (:name %)) @errors)))})))}
       {:pretty true}))
 
 (System/exit 0)

--- a/tests/example-all-fail/expected_results.json
+++ b/tests/example-all-fail/expected_results.json
@@ -46,6 +46,5 @@
     "status" : "fail",
     "test_code" : "(is (not (leap/leap-year? 1800)))",
     "message" : "Expected (not (leap/leap-year? 1800)) but got (not (not true))"
-  } ],
-  "message" : null
+  } ]
 }

--- a/tests/example-partial-fail/expected_results.json
+++ b/tests/example-partial-fail/expected_results.json
@@ -39,6 +39,5 @@
     "name" : "year-divisible-by-200-but-not-by-400",
     "status" : "pass",
     "test_code" : "(is (not (leap/leap-year? 1800)))"
-  } ],
-  "message" : null
+  } ]
 }

--- a/tests/example-success/expected_results.json
+++ b/tests/example-success/expected_results.json
@@ -37,6 +37,5 @@
     "name" : "year-divisible-by-200-but-not-by-400",
     "status" : "pass",
     "test_code" : "(is (not (leap/leap-year? 1800)))"
-  } ],
-  "message" : null
+  } ]
 }


### PR DESCRIPTION
This should fix #20, which was happening because I had not considered cases where errors are caught within the test run but do not blow up the whole script. This was confusingly giving the impression that the tests were passing but not allowing the student to proceed.