### PR TITLE
bump babashka version in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM babashka/babashka:0.8.1-SNAPSHOT-alpine
-LABEL Name=clojure-test-runner Version=0.0.3
+FROM babashka/babashka:0.10.164-SNAPSHOT-alpine
+LABEL Name=clojure-test-runner Version=0.0.4
 
 RUN apk add --no-cache jq coreutils bash
 


### PR DESCRIPTION
New classes were recently added to the Clojure interpreter, lessening the differences between JVM Clojure which give students trouble occasionally. Upgrading the Docker image to the latest version of babashka will translate to fewer compatibility issues between the online editor and a standard Clojure environment.

For example, see `indexOf`: https://github.com/babashka/babashka/commit/c09ff9e61c3c9ff9baca6cf0fd8c38a36444e855